### PR TITLE
Get the element value, not just if the node exists

### DIFF
--- a/mammoth/docx/body_xml.py
+++ b/mammoth/docx/body_xml.py
@@ -71,7 +71,15 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
 
     def text(element):
         return _success(documents.Text(_inner_text(element)))
-
+   
+    def element_or_value(element):
+        if element and ("w:val" in element.attributes):
+            element_value = element.attributes["w:val"]
+            if element_value == 'false':
+                return False
+            elif element_value == 'true':
+                return True
+        return element
 
     def run(element):
         properties = element.find_child_or_null("w:rPr")
@@ -79,10 +87,10 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
             .find_child_or_null("w:vertAlign") \
             .attributes.get("w:val")
         
-        is_bold = properties.find_child("w:b")
-        is_italic = properties.find_child("w:i")
-        is_underline = properties.find_child("w:u")
-        is_strikethrough = properties.find_child("w:strike")
+        is_bold = element_or_value(properties.find_child("w:b"))
+        is_italic = element_or_value(properties.find_child("w:i"))
+        is_underline = element_or_value(properties.find_child("w:u"))
+        is_strikethrough = element_or_value(properties.find_child("w:strike"))
         
         return _ReadResult.map_results(
             _read_run_style(properties),


### PR DESCRIPTION
Hi, 

Thank you for this awesome project.

I had an error where all the output was with strikethrough. After analyzing, it was only checking if the node 'strikethrough' exists, and not checking it value.

This pull request fix this
